### PR TITLE
remove the react-native-electrode-bridge (avoid conflict)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "dependencies": {
     "react": "16.8.3",
     "react-native": "0.59.8",
-    "react-native-electrode-bridge": "1.5.17",
     "react-native-ernmovie-api": "0.0.11",
     "react-native-ernnavigation-api": "0.0.5"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2976,13 +2976,6 @@ react-devtools-core@^3.6.0:
     shell-quote "^1.6.1"
     ws "^3.3.1"
 
-react-native-electrode-bridge@1.5.17:
-  version "1.5.17"
-  resolved "https://registry.yarnpkg.com/react-native-electrode-bridge/-/react-native-electrode-bridge-1.5.17.tgz#7aa9ad920d8f704482dd63f12c8ac55570a1d2fd"
-  dependencies:
-    events "^1.1.1"
-    uuid "^3.0.0"
-
 react-native-electrode-bridge@1.5.x:
   version "1.5.16"
   resolved "https://registry.yarnpkg.com/react-native-electrode-bridge/-/react-native-electrode-bridge-1.5.16.tgz#49fed03cf08c0fe95d11a44315901d81b0309c08"


### PR DESCRIPTION
```
[ == MISMATCHING NATIVE DEPENDENCIES ==]
✖ ├─ react-native-electrode-bridge@1.5.17 [1.5.17]
✖ │  └─ movielistminiapp@0.0.32 [0.0.32]
✖ └─ react-native-electrode-bridge@1.5.x [1.5.19]
✖    ├─ react-native-ernmovie-api@0.0.11 [0.0.11]
✖    │  └─ movielistminiapp@0.0.32 [0.0.32]
✖    └─ react-native-ernnavigation-api@0.0.5 [0.0.5]
✖       └─ movielistminiapp@0.0.32 [0.0.32]
✖ 
✖ runLocalCompositeGen failed: Error: The following plugins are not using compatible versions : 
✖      react-native-electrode-bridge
[ Generating Composite locally (Failed) ]
✖ An error occurred: The following plugins are not using compatible versions : 
✖      react-native-electrode-bridge
```